### PR TITLE
Visibility flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 # netbeans
 /nbproject
 
+# IntelliJ IDEA
+/.idea/
+
 # we use maven!
 /build.xml
 

--- a/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
+++ b/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
@@ -178,7 +178,7 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
 
         return true;
     }
-    
+
     private void addStyle(String resid, String worldid, AreaMarker m, ProtectedRegion region) {
         AreaStyle as = cusstyle.get(worldid + "/" + resid);
         if(as == null) {
@@ -456,7 +456,7 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
             log.info("Custom flag '" + VISIBLE_FLAG + "' not registered");
         }
     }
-    
+
     private boolean reload = false;
     
     private void activate() {        

--- a/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
+++ b/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
@@ -51,13 +51,11 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
     private static final String DEF_INFOWINDOW = "<div class=\"infowindow\"><span style=\"font-size:120%;\">%regionname%</span><br /> Owner <span style=\"font-weight:bold;\">%playerowners%</span><br />Flags<br /><span style=\"font-weight:bold;\">%flags%</span></div>";
     public static final String BOOST_FLAG = "dynmap-boost";
     public static final String VISIBLE_FLAG = "dynmap-showonmap";
-    public static final String HIDE_FLAG = "dynmap-hideonmap";
     Plugin dynmap;
     DynmapAPI api;
     MarkerAPI markerapi;
     BooleanFlag boost_flag;
     BooleanFlag visible_flag;
-    BooleanFlag hide_flag;
     int updatesPerTick = 20;
 
     FileConfiguration cfg;
@@ -167,15 +165,12 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
             return false;
 
         if (vbfEnable) {
-            Boolean hideFlag = region.getFlag(hide_flag);
-            if (hideFlag != null && hideFlag)
-                return false;
+            Boolean visibleFlag = region.getFlag(visible_flag);
 
-            if (vbfHideByDefault) {
-                Boolean visibleFlag = region.getFlag(visible_flag);
-                if (visibleFlag == null || !visibleFlag)
-                    return false;
-            }
+            if (visibleFlag == null)
+                return !vbfHideByDefault;
+
+            return visibleFlag;
         }
 
         return true;
@@ -456,17 +451,6 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
         }
         if (visible_flag == null) {
             log.info("Custom flag '" + VISIBLE_FLAG + "' not registered");
-        }
-
-        try {
-            BooleanFlag hideFlag = new BooleanFlag(HIDE_FLAG);
-            fr.register(hideFlag);
-            hide_flag = hideFlag;
-        } catch (FlagConflictException ex) {
-            log.info("Error registering flag - " + ex.getMessage());
-        }
-        if (hide_flag == null) {
-            log.info("Custom flag '" + HIDE_FLAG + "' not registered");
         }
     }
     

--- a/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
+++ b/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
@@ -71,7 +71,7 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
     Set<String> hidden;
     boolean stop; 
     int maxdepth;
-    boolean vbfEnable = false;
+    boolean vbfEnable        = false;
     boolean vbfHideByDefault = true;
 
     @Override
@@ -158,17 +158,20 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
             final @Nullable ProtectedRegion region,
             final @Nullable World world
     ) {
-        if (region == null || world == null)
+        if (region == null || world == null) {
             return false;
+        }
 
-        if (!(this.isVisible(region.getId(), world.getName())))
+        if (!(this.isVisible(region.getId(), world.getName()))) {
             return false;
+        }
 
         if (vbfEnable) {
             Boolean visibleFlag = region.getFlag(visible_flag);
 
-            if (visibleFlag == null)
+            if (visibleFlag == null) {
                 return !vbfHideByDefault;
+            }
 
             return visibleFlag;
         }
@@ -493,8 +496,14 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
         infowindow = cfg.getString("infowindow", DEF_INFOWINDOW);
         maxdepth = cfg.getInt("maxdepth", 16);
         updatesPerTick = cfg.getInt("updates-per-tick", 20);
-        vbfEnable = cfg.getBoolean("visibility-by-flags.enable", false);
-        vbfHideByDefault = cfg.getBoolean("visibility-by-flags.hide-by-default", true);
+        vbfEnable = cfg.getBoolean(
+                "visibility-by-flags.enable",
+                false
+        );
+        vbfHideByDefault = cfg.getBoolean(
+                "visibility-by-flags.hide-by-default",
+                true
+        );
 
         /* Get style information */
         defstyle = new AreaStyle(cfg, "regionstyle");

--- a/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
+++ b/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
@@ -69,7 +69,8 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
     Set<String> hidden;
     boolean stop; 
     int maxdepth;
-    boolean visibilityByFlags = false;
+    boolean visibilityByFlagsEnable = false;
+    boolean visibilityByFlagsDefault = true;
 
     @Override
     public void onLoad() {
@@ -468,7 +469,8 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
         infowindow = cfg.getString("infowindow", DEF_INFOWINDOW);
         maxdepth = cfg.getInt("maxdepth", 16);
         updatesPerTick = cfg.getInt("updates-per-tick", 20);
-        visibilityByFlags = cfg.getBoolean("visibility-by-flags", false);
+        visibilityByFlagsEnable = cfg.getBoolean("visibility-by-flags.enable", false);
+        visibilityByFlagsDefault = cfg.getBoolean("visibility-by-flags.hide-by-default", true);
 
         /* Get style information */
         defstyle = new AreaStyle(cfg, "regionstyle");

--- a/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
+++ b/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
@@ -71,8 +71,8 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
     Set<String> hidden;
     boolean stop; 
     int maxdepth;
-    boolean vbfEnable        = false;
-    boolean vbfHideByDefault = true;
+    boolean vbfEnabled;
+    boolean vbfHideByDefault;
 
     @Override
     public void onLoad() {
@@ -166,7 +166,7 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
             return false;
         }
 
-        if (vbfEnable) {
+        if (vbfEnabled) {
             Boolean visibleFlag = region.getFlag(visible_flag);
 
             if (visibleFlag == null) {
@@ -496,7 +496,7 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
         infowindow = cfg.getString("infowindow", DEF_INFOWINDOW);
         maxdepth = cfg.getInt("maxdepth", 16);
         updatesPerTick = cfg.getInt("updates-per-tick", 20);
-        vbfEnable = cfg.getBoolean(
+        vbfEnabled = cfg.getBoolean(
                 "visibility-by-flags.enable",
                 false
         );

--- a/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
+++ b/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
@@ -47,10 +48,12 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
     private static Logger log;
     private static final String DEF_INFOWINDOW = "<div class=\"infowindow\"><span style=\"font-size:120%;\">%regionname%</span><br /> Owner <span style=\"font-weight:bold;\">%playerowners%</span><br />Flags<br /><span style=\"font-weight:bold;\">%flags%</span></div>";
     public static final String BOOST_FLAG = "dynmap-boost";
+    public static final String VISIBLE_FLAG = "dynmap-showonmap";
     Plugin dynmap;
     DynmapAPI api;
     MarkerAPI markerapi;
     BooleanFlag boost_flag;
+    BooleanFlag visible_flag;
     int updatesPerTick = 20;
 
     FileConfiguration cfg;
@@ -401,9 +404,10 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
     }
     
     private void registerCustomFlags() {
+        FlagRegistry fr = WorldGuard.getInstance().getFlagRegistry();
+
         try {
             BooleanFlag bf = new BooleanFlag(BOOST_FLAG);
-            FlagRegistry fr = WorldGuard.getInstance().getFlagRegistry();
         	fr.register(bf);
             boost_flag = bf;
         } catch (Exception x) {
@@ -411,6 +415,17 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
         }
         if (boost_flag == null) {
             log.info("Custom flag '" + BOOST_FLAG + "' not registered");
+        }
+
+        try {
+            BooleanFlag visibleFlag = new BooleanFlag(VISIBLE_FLAG);
+            fr.register(visibleFlag);
+            visible_flag = visibleFlag;
+        } catch (FlagConflictException ex) {
+            log.info("Error registering flag - " + ex.getMessage());
+        }
+        if (visible_flag == null) {
+            log.info("Custom flag '" + VISIBLE_FLAG + "' not registered");
         }
     }
     

--- a/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
+++ b/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
@@ -66,6 +66,7 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
     Set<String> hidden;
     boolean stop; 
     int maxdepth;
+    boolean visibilityByFlags = false;
 
     @Override
     public void onLoad() {
@@ -452,6 +453,7 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
         infowindow = cfg.getString("infowindow", DEF_INFOWINDOW);
         maxdepth = cfg.getInt("maxdepth", 16);
         updatesPerTick = cfg.getInt("updates-per-tick", 20);
+        visibilityByFlags = cfg.getBoolean("visibility-by-flags", false);
 
         /* Get style information */
         defstyle = new AreaStyle(cfg, "regionstyle");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -52,3 +52,8 @@ maxdepth: 16
     
 # Limit number of regions processed per tick (avoid lag spikes on servers with lots of regions)
 updates-per-tick: 20
+
+# Control the visibility of regions by WorldGuard flags
+visibility-by-flags:
+  enable: false
+  hide-by-default: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -55,5 +55,7 @@ updates-per-tick: 20
 
 # Control the visibility of regions by WorldGuard flags
 visibility-by-flags:
+  # Enable the feature to use WorldGuard flags to control visibility of regions
   enable: false
+  # Hide regions, without the 'dynmap-showonmap' WorldGuard flag
   hide-by-default: true


### PR DESCRIPTION
Adds feature to use WorldGuard flags to control visibility of region.
Regions, which are hidden by the config, will still be hidden. Also the defaults are set to work as the previous version of the plugin. If the configuration is not changed, everything remains consistent.

Added configuration options:
- visibility-by-flags.enable (Default: false) # Enable the feature to use WorldGuard flags to control visibility of regions
- visibility-by-flags.hide-by-default (Default: true)  # Hide regions, without the 'dynmap-showonmap' WorldGuard flag

Added WorldGuard flag:
dynmap-showonmap:
- null / unset: Default from confguration will be used (visibility-by-flags.hide-by-default)
- false: Region will be hidden
- true: Region will be shown (if not hidden by previous system)