### PR TITLE
Flag filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 # netbeans
 /nbproject
 
+# IntelliJ IDEA
+/.idea/
+
 # we use maven!
 /build.xml
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,11 @@
 	<groupId>org.dynmap</groupId>
 	<artifactId>Dynmap-WorldGuard</artifactId>
 
+	<properties>
+		<!-- dependency versions -->
+		<json.version>20220924</json.version>
+	</properties>
+
 	<build>
 		<resources>
 			<resource>
@@ -137,6 +142,12 @@
 			<artifactId>squirrelid</artifactId>
 			<version>0.2.0</version>
 			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>${json.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.sk89q.worldedit</groupId>

--- a/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
+++ b/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
@@ -45,6 +45,7 @@ import com.sk89q.worldguard.protection.regions.ProtectedPolygonalRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionContainer;
 import com.sk89q.worldguard.protection.regions.RegionType;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 public class DynmapWorldGuardPlugin extends JavaPlugin {
@@ -150,9 +151,12 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
             if (flagFilterEnabled) {
                 flagFilter = !flagFilterHiddenByDefault;
 
-                Object flagFilterValue = flagsJson.get(flagName);
-                if (flagFilterValue instanceof Boolean) {
-                    flagFilter = (Boolean)flagFilterValue;
+                try {
+                    Object flagFilterValue = flagsJson.get(flagName);
+                    if (flagFilterValue instanceof Boolean) {
+                        flagFilter = (Boolean)flagFilterValue;
+                    }
+                } catch (JSONException e) {
                 }
             }
 

--- a/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
+++ b/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
@@ -136,7 +136,7 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
                                                flagsFilter
                                            );
         Map<Flag<?>, Object> map         = region.getFlags();
-        String               flgs        = "";
+        StringBuilder        flgs        = new StringBuilder();
         for (Flag<?> f : map.keySet()) {
             String flagName = f.getName();
 
@@ -151,10 +151,13 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
             }
 
             if (flagFilter) {
-                flgs += f.getName() + ": " + map.get(f).toString() + "<br/>";
+                flgs.append(flagName);
+                flgs.append(": ");
+                flgs.append(map.get(f).toString());
+                flgs.append("<br/>");
             }
         }
-        v = v.replace("%flags%", flgs);
+        v = v.replace("%flags%", flgs.toString());
 
         return v;
     }

--- a/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
+++ b/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
@@ -11,6 +11,8 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.sk89q.worldguard.protection.flags.StringFlag;
+import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
@@ -47,10 +49,12 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
     private static Logger log;
     private static final String DEF_INFOWINDOW = "<div class=\"infowindow\"><span style=\"font-size:120%;\">%regionname%</span><br /> Owner <span style=\"font-weight:bold;\">%playerowners%</span><br />Flags<br /><span style=\"font-weight:bold;\">%flags%</span></div>";
     public static final String BOOST_FLAG = "dynmap-boost";
+    public static final String FLAGS_FILTER_FLAG = "dynmap-flags-filter";
     Plugin dynmap;
     DynmapAPI api;
     MarkerAPI markerapi;
     BooleanFlag boost_flag;
+    StringFlag flags_filter_flag;
     int updatesPerTick = 20;
 
     FileConfiguration cfg;
@@ -400,9 +404,10 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
     }
     
     private void registerCustomFlags() {
+        FlagRegistry fr = WorldGuard.getInstance().getFlagRegistry();
+
         try {
             BooleanFlag bf = new BooleanFlag(BOOST_FLAG);
-            FlagRegistry fr = WorldGuard.getInstance().getFlagRegistry();
         	fr.register(bf);
             boost_flag = bf;
         } catch (Exception x) {
@@ -410,6 +415,17 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
         }
         if (boost_flag == null) {
             log.info("Custom flag '" + BOOST_FLAG + "' not registered");
+        }
+
+        try {
+            StringFlag flagsFilterFlag = new StringFlag(FLAGS_FILTER_FLAG);
+            fr.register(flagsFilterFlag);
+            flags_filter_flag = flagsFilterFlag;
+        } catch (FlagConflictException ex) {
+            log.info("Error registering flag - " + ex.getMessage());
+        }
+        if (flags_filter_flag == null) {
+            log.info("Custom flag '" + FLAGS_FILTER_FLAG + "' not registered");
         }
     }
     

--- a/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
+++ b/src/main/java/org/dynmap/worldguard/DynmapWorldGuardPlugin.java
@@ -72,6 +72,8 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
     Set<String> hidden;
     boolean stop; 
     int maxdepth;
+    boolean flagFilterEnabled;
+    boolean flagFilterHiddenByDefault;
 
     @Override
     public void onLoad() {
@@ -144,10 +146,14 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
                 continue;
             }
 
-            boolean flagFilter      = false;
-            Object  flagFilterValue = flagsJson.get(flagName);
-            if (flagFilterValue instanceof Boolean) {
-                flagFilter = (Boolean)flagFilterValue;
+            boolean flagFilter = true;
+            if (flagFilterEnabled) {
+                flagFilter = !flagFilterHiddenByDefault;
+
+                Object flagFilterValue = flagsJson.get(flagName);
+                if (flagFilterValue instanceof Boolean) {
+                    flagFilter = (Boolean)flagFilterValue;
+                }
             }
 
             if (flagFilter) {
@@ -493,6 +499,14 @@ public class DynmapWorldGuardPlugin extends JavaPlugin {
         infowindow = cfg.getString("infowindow", DEF_INFOWINDOW);
         maxdepth = cfg.getInt("maxdepth", 16);
         updatesPerTick = cfg.getInt("updates-per-tick", 20);
+        flagFilterEnabled         = cfg.getBoolean(
+                "flag-filter.enable",
+                false
+        );
+        flagFilterHiddenByDefault = cfg.getBoolean(
+                "flag-filter.hidden-by-default",
+                false
+        );
 
         /* Get style information */
         defstyle = new AreaStyle(cfg, "regionstyle");

--- a/src/main/java/org/dynmap/worldguard/StringFlagUtils.java
+++ b/src/main/java/org/dynmap/worldguard/StringFlagUtils.java
@@ -1,0 +1,72 @@
+package org.dynmap.worldguard;
+
+import com.google.common.base.Strings;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import javax.annotation.Nullable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class StringFlagUtils {
+	private static final String  KEY_GROUP     = "key";
+	private static final String  VALUE_GROUP   = "value";
+	private static final Pattern ENTRY_PATTERN = Pattern.compile(
+			"[\"']?(?<" +
+			StringFlagUtils.KEY_GROUP +
+			">[\\w-])[\"']?([:=][\"']?(?<" +
+			StringFlagUtils.VALUE_GROUP +
+			">[\\w-])[\"']?)?"
+	);
+
+	public static JSONObject generateJson(
+			final @Nullable String content
+	)
+	throws JSONException {
+		if (Strings.isNullOrEmpty(content)) {
+			return new JSONObject();
+		}
+
+		String jsonString = content.trim().replaceAll(
+				"[ \\t\\v\\r\\n]+",
+				""
+		);
+
+		if (!jsonString.startsWith("{") && !jsonString.endsWith("}")) {
+			final StringBuilder jsonBuilder = new StringBuilder();
+			jsonBuilder.append('{');
+			String prefix = "";
+			for (String entry : jsonString.split("[,;]+")) {
+				final Matcher matcher = StringFlagUtils.ENTRY_PATTERN.matcher(
+						entry);
+
+				if (!matcher.matches()) {
+					continue;
+				}
+
+				String key   = matcher.group(StringFlagUtils.KEY_GROUP);
+				String value = matcher.group(StringFlagUtils.VALUE_GROUP);
+
+				if ("yes".equalsIgnoreCase(value) || "allow".equalsIgnoreCase(
+						value)) {
+					value = Boolean.TRUE.toString();
+				}
+
+				boolean boolValue = Boolean.parseBoolean(value);
+
+				jsonBuilder.append(prefix);
+				jsonBuilder.append('\"');
+				jsonBuilder.append(key);
+				jsonBuilder.append("\":");
+				jsonBuilder.append(boolValue);
+
+				prefix = ",";
+			}
+			jsonBuilder.append('}');
+
+			jsonString = jsonBuilder.toString();
+		}
+
+		return new JSONObject(jsonString);
+	}
+}

--- a/src/main/java/org/dynmap/worldguard/StringFlagUtils.java
+++ b/src/main/java/org/dynmap/worldguard/StringFlagUtils.java
@@ -12,15 +12,12 @@ public class StringFlagUtils {
 	private static final String  KEY_GROUP     = "key";
 	private static final String  VALUE_GROUP   = "value";
 	private static final Pattern ENTRY_PATTERN = Pattern.compile(
-			"[\"']?(?<" +
-			StringFlagUtils.KEY_GROUP +
-			">[\\w-])[\"']?([:=][\"']?(?<" +
-			StringFlagUtils.VALUE_GROUP +
-			">[\\w-])[\"']?)?"
-	);
+		"[\"']?(?<" + StringFlagUtils.KEY_GROUP +
+		">[\\w-])[\"']?([:=][\"']?(?<" + StringFlagUtils.VALUE_GROUP +
+		">[\\w-])[\"']?)?");
 
 	public static JSONObject generateJson(
-			final @Nullable String content
+		final @Nullable String content
 	)
 	throws JSONException {
 		if (Strings.isNullOrEmpty(content)) {
@@ -28,8 +25,8 @@ public class StringFlagUtils {
 		}
 
 		String jsonString = content.trim().replaceAll(
-				"[ \\t\\v\\r\\n]+",
-				""
+			"[ \\t\\v\\r\\n]+",
+			""
 		);
 
 		if (!jsonString.startsWith("{") && !jsonString.endsWith("}")) {
@@ -38,7 +35,8 @@ public class StringFlagUtils {
 			String prefix = "";
 			for (String entry : jsonString.split("[,;]+")) {
 				final Matcher matcher = StringFlagUtils.ENTRY_PATTERN.matcher(
-						entry);
+					entry
+				);
 
 				if (!matcher.matches()) {
 					continue;
@@ -47,8 +45,10 @@ public class StringFlagUtils {
 				String key   = matcher.group(StringFlagUtils.KEY_GROUP);
 				String value = matcher.group(StringFlagUtils.VALUE_GROUP);
 
-				if ("yes".equalsIgnoreCase(value) || "allow".equalsIgnoreCase(
-						value)) {
+				if (
+					"yes".equalsIgnoreCase(value) ||
+					"allow".equalsIgnoreCase(value)
+				) {
 					value = Boolean.TRUE.toString();
 				}
 

--- a/src/main/java/org/dynmap/worldguard/StringFlagUtils.java
+++ b/src/main/java/org/dynmap/worldguard/StringFlagUtils.java
@@ -13,8 +13,8 @@ public class StringFlagUtils {
 	private static final String  VALUE_GROUP   = "value";
 	private static final Pattern ENTRY_PATTERN = Pattern.compile(
 		"[\"']?(?<" + StringFlagUtils.KEY_GROUP +
-		">[\\w-])[\"']?([:=][\"']?(?<" + StringFlagUtils.VALUE_GROUP +
-		">[\\w-])[\"']?)?");
+		">[\\w-]+)[\"']?([:=][\"']?(?<" + StringFlagUtils.VALUE_GROUP +
+		">[\\w-]+)[\"']?)?");
 
 	public static JSONObject generateJson(
 		final @Nullable String content

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -52,3 +52,10 @@ maxdepth: 16
     
 # Limit number of regions processed per tick (avoid lag spikes on servers with lots of regions)
 updates-per-tick: 20
+
+# Filter region flags in info window
+flag-filter:
+  # Enable the flag filter feature
+  enable:            false
+  # Should the flags hidden by default
+  hidden-by-default: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,3 +5,5 @@ author: mikeprimm
 depend: [ dynmap, WorldGuard ]
 api-version: 1.13
 
+libraries:
+  - org.json:json:${json.version}

--- a/src/test/java/org/dynmap/worldguard/StringFlagUtilsTest.java
+++ b/src/test/java/org/dynmap/worldguard/StringFlagUtilsTest.java
@@ -1,0 +1,24 @@
+package org.dynmap.worldguard;
+
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringFlagUtilsTest {
+	@Test
+	public void testGenerateJsonEmpty() {
+		JSONObject jsonObject = StringFlagUtils.generateJson("");
+
+		Assert.assertTrue(jsonObject.isEmpty());
+	}
+
+	@Test
+	public void testGenerateJsonMultipleFlags() {
+		JSONObject jsonObject = StringFlagUtils.generateJson(
+			"greeting:allow,farewell:deny"
+		);
+
+		Assert.assertTrue(jsonObject.getBoolean("greeting"));
+		Assert.assertFalse(jsonObject.getBoolean("farewell"));
+	}
+}


### PR DESCRIPTION
Added option to control the flags in popups by a new flag called `dynmap-flags-filter`. So you could control, which information are public on the online map.

Usage:
The flag should contain a comma-separated (,) list of flags with the information to show it, separated by an colon (:).
Eg.: `dynmap-flags-filter=greeting:allow,farewell:deny`, will show the greeting and hide the farewell flag.

Also some configuration options were added to control the behavior of this feature.
```
# Filter region flags in info window
flag-filter:
  # Enable the flag filter feature
  enable: true
  # Should the flags hidden by default
  hidden-by-default: false
```

If the configuration is not changed, everything remains consistent.